### PR TITLE
Decrease deployment target to iOS 15 to fit Harmony requirements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "WrappingHStack",
     platforms: [
-        .iOS(.v16),
+        .iOS(.v15),
         .macOS(.v13),
         .tvOS(.v16),
         .watchOS(.v9),

--- a/Sources/WrappingHStack/WrappingHStack.swift
+++ b/Sources/WrappingHStack/WrappingHStack.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 /// A view that arranges its subviews in horizontal line and wraps them to the next lines if necessary.
+@available(iOS 16, *)
 public struct WrappingHStack: Layout {
     /// The guide for aligning the subviews in this stack. This guide has the same screen coordinate for every subview.
     public var alignment: Alignment
@@ -108,6 +109,7 @@ public struct WrappingHStack: Layout {
     }
 }
 
+@available(iOS 16, *)
 extension WrappingHStack {
     struct Row {
         var elements: [(index: Int, size: CGSize, xOffset: CGFloat)] = []

--- a/WrappingHStackLayout.podspec
+++ b/WrappingHStackLayout.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.authors               = 'Konstantin Semianov <ksemianov>'
   s.license               = { :type => 'MIT', :file => 'LICENSE' }
   s.swift_version         = '5'
-  s.ios.deployment_target = '16.0'
+  s.ios.deployment_target = '15.0'
   s.osx.deployment_target = '13.0'
   s.source                = { :git => 'https://github.com/ksemianov/WrappingHStack.git', :tag => s.version }
   s.source_files          = 'Sources/WrappingHStack/*.swift'


### PR DESCRIPTION
In order to integrate the framework into Harmony, we need to make it suport deployment target for iOS 15 and just make the Layout component available on iOS 16.